### PR TITLE
feat: support sign in numeric check

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -606,17 +606,26 @@ public final class StringUtils {
         if (str == null || str.isEmpty()) {
             return false;
         }
+        int start = 0;
+        // Allow leading '+' or '-' sign
+        if (str.charAt(0) == '-' || str.charAt(0) == '+') {
+            if (str.length() == 1) {
+                return false;
+            }
+            start = 1;
+        }
         boolean hasDot = false;
         int sz = str.length();
-        for (int i = 0; i < sz; i++) {
-            if (str.charAt(i) == '.') {
+        for (int i = start; i < sz; i++) {
+            char ch = str.charAt(i);
+            if (ch == '.') {
                 if (hasDot || !allowDot) {
                     return false;
                 }
                 hasDot = true;
                 continue;
             }
-            if (!Character.isDigit(str.charAt(i))) {
+            if (!Character.isDigit(ch)) {
                 return false;
             }
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -318,6 +318,9 @@ class StringUtilsTest {
         assertThat(StringUtils.isNumeric("123.", true), is(true));
         assertThat(StringUtils.isNumeric(".123", true), is(true));
         assertThat(StringUtils.isNumeric("..123", true), is(false));
+        assertThat(StringUtils.isNumeric("-1", true), is(true));
+        assertThat(StringUtils.isNumeric("+1.23", true), is(true));
+        assertThat(StringUtils.isNumeric("-", true), is(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support `+` or `-` sign in `StringUtils.isNumeric`
- add tests for signed numbers
- translate comment about sign handling to English

## Testing
- `mvn -q -pl dubbo-common -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b3527057348330b2ab8d56029d05fc