### PR TITLE
feat(common): add optional sign support to StringUtils.isNumeric

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -603,20 +603,33 @@ public final class StringUtils {
     }
 
     public static boolean isNumeric(String str, boolean allowDot) {
+        return isNumeric(str, allowDot, false);
+    }
+
+    public static boolean isNumeric(String str, boolean allowDot, boolean allowSign) {
         if (str == null || str.isEmpty()) {
             return false;
         }
+        int start = 0;
+        // Allow leading '+' or '-' sign when allowSign is true
+        if (allowSign && (str.charAt(0) == '-' || str.charAt(0) == '+')) {
+            if (str.length() == 1) {
+                return false;
+            }
+            start = 1;
+        }
         boolean hasDot = false;
         int sz = str.length();
-        for (int i = 0; i < sz; i++) {
-            if (str.charAt(i) == '.') {
+        for (int i = start; i < sz; i++) {
+            char ch = str.charAt(i);
+            if (ch == '.') {
                 if (hasDot || !allowDot) {
                     return false;
                 }
                 hasDot = true;
                 continue;
             }
-            if (!Character.isDigit(str.charAt(i))) {
+            if (!Character.isDigit(ch)) {
                 return false;
             }
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -318,6 +318,20 @@ class StringUtilsTest {
         assertThat(StringUtils.isNumeric("123.", true), is(true));
         assertThat(StringUtils.isNumeric(".123", true), is(true));
         assertThat(StringUtils.isNumeric("..123", true), is(false));
+
+        assertThat(StringUtils.isNumeric("-1", true), is(false));
+        assertThat(StringUtils.isNumeric("+1.23", true), is(false));
+        assertThat(StringUtils.isNumeric("-", true), is(false));
+
+        assertThat(StringUtils.isNumeric("-1", true, true), is(true));
+        assertThat(StringUtils.isNumeric("+1.23", true, true), is(true));
+        assertThat(StringUtils.isNumeric("-", true, true), is(false));
+        assertThat(StringUtils.isNumeric("+", true, true), is(false));
+        assertThat(StringUtils.isNumeric("-1", false, true), is(true));
+        assertThat(StringUtils.isNumeric("+1", false, true), is(true));
+        assertThat(StringUtils.isNumeric("+1.23", false, true), is(false));
+        assertThat(StringUtils.isNumeric(null, true, true), is(false));
+        assertThat(StringUtils.isNumeric("", true, true), is(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow `StringUtils.isNumeric` to optionally accept leading plus/minus sign
- expand unit tests for signed numeric strings and edge cases

## Testing
- `mvn -q -pl dubbo-common -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3527057348330b2ab8d56029d05fc