### PR TITLE
fix(http12): harden XML deserialization

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/StringUtils.java
@@ -603,20 +603,33 @@ public final class StringUtils {
     }
 
     public static boolean isNumeric(String str, boolean allowDot) {
+        return isNumeric(str, allowDot, false);
+    }
+
+    public static boolean isNumeric(String str, boolean allowDot, boolean allowSign) {
         if (str == null || str.isEmpty()) {
             return false;
         }
+        int start = 0;
+        // Allow leading '+' or '-' sign when allowSign is true
+        if (allowSign && (str.charAt(0) == '-' || str.charAt(0) == '+')) {
+            if (str.length() == 1) {
+                return false;
+            }
+            start = 1;
+        }
         boolean hasDot = false;
         int sz = str.length();
-        for (int i = 0; i < sz; i++) {
-            if (str.charAt(i) == '.') {
+        for (int i = start; i < sz; i++) {
+            char ch = str.charAt(i);
+            if (ch == '.') {
                 if (hasDot || !allowDot) {
                     return false;
                 }
                 hasDot = true;
                 continue;
             }
-            if (!Character.isDigit(str.charAt(i))) {
+            if (!Character.isDigit(ch)) {
                 return false;
             }
         }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/StringUtilsTest.java
@@ -318,6 +318,20 @@ class StringUtilsTest {
         assertThat(StringUtils.isNumeric("123.", true), is(true));
         assertThat(StringUtils.isNumeric(".123", true), is(true));
         assertThat(StringUtils.isNumeric("..123", true), is(false));
+
+        assertThat(StringUtils.isNumeric("-1", true), is(false));
+        assertThat(StringUtils.isNumeric("+1.23", true), is(false));
+        assertThat(StringUtils.isNumeric("-", true), is(false));
+
+        assertThat(StringUtils.isNumeric("-1", true, true), is(true));
+        assertThat(StringUtils.isNumeric("+1.23", true, true), is(true));
+        assertThat(StringUtils.isNumeric("-", true, true), is(false));
+        assertThat(StringUtils.isNumeric("+", true, true), is(false));
+        assertThat(StringUtils.isNumeric("-1", false, true), is(true));
+        assertThat(StringUtils.isNumeric("+1", false, true), is(true));
+        assertThat(StringUtils.isNumeric("+1.23", false, true), is(false));
+        assertThat(StringUtils.isNumeric(null, true, true), is(false));
+        assertThat(StringUtils.isNumeric("", true, true), is(false));
     }
 
     @Test

--- a/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/XmlCodec.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/main/java/org/apache/dubbo/remoting/http12/message/codec/XmlCodec.java
@@ -26,6 +26,7 @@ import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
@@ -58,6 +59,9 @@ public class XmlCodec implements HttpMessageCodec {
     @Override
     public Object decode(InputStream is, Class<?> targetType, Charset charset) throws DecodeException {
         try {
+            if (targetType == Object.class || !targetType.isAnnotationPresent(XmlRootElement.class)) {
+                throw new DecodeException("Target type " + targetType.getName() + " is not allowed for xml deserialization");
+            }
             try (InputStreamReader reader = new InputStreamReader(is, charset)) {
                 InputSource inputSource = new InputSource(reader);
                 inputSource.setEncoding(charset.name());
@@ -81,7 +85,10 @@ public class XmlCodec implements HttpMessageCodec {
         spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         spf.setXIncludeAware(false);
-        return spf.newSAXParser();
+        SAXParser saxParser = spf.newSAXParser();
+        saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        return saxParser;
     }
 
     @Override

--- a/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/XmlSafetyTest.java
+++ b/dubbo-remoting/dubbo-remoting-http12/src/test/java/org/apache/dubbo/remoting/http12/message/codec/XmlSafetyTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.apache.dubbo.remoting.http12.exception.DecodeException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @EnabledOnOs(OS.LINUX)
 public class XmlSafetyTest {
@@ -44,40 +46,34 @@ public class XmlSafetyTest {
 
     @Test
     void testSafe1() {
-        try {
-            InputStream in = new ByteArrayInputStream(("<xml>\n" + "  <dynamic-proxy>\n"
-                            + "    <interface>java.util.List</interface>\n"
-                            + "    <handler class=\"java.beans.EventHandler\">\n"
-                            + "      <target class=\"java.lang.ProcessBuilder\">\n"
-                            + "        <command>\n"
-                            + "          <string>" + "sleep" + "</string>\n"
-                            + "          <string>" + "60" + "</string>\n"
-                            + "        </command>\n"
-                            + "      </target>\n"
-                            + "      <action>start</action>\n"
-                            + "    </handler>\n"
-                            + "  </dynamic-proxy>\n"
-                            + "</xml>")
-                    .getBytes());
-            new XmlCodec().decode(in, Object.class);
-        } catch (Exception e) {
-        }
+        InputStream in = new ByteArrayInputStream(("<xml>\n" + "  <dynamic-proxy>\n"
+                        + "    <interface>java.util.List</interface>\n"
+                        + "    <handler class=\"java.beans.EventHandler\">\n"
+                        + "      <target class=\"java.lang.ProcessBuilder\">\n"
+                        + "        <command>\n"
+                        + "          <string>" + "sleep" + "</string>\n"
+                        + "          <string>" + "60" + "</string>\n"
+                        + "        </command>\n"
+                        + "      </target>\n"
+                        + "      <action>start</action>\n"
+                        + "    </handler>\n"
+                        + "  </dynamic-proxy>\n"
+                        + "</xml>")
+                .getBytes());
+        assertThrows(DecodeException.class, () -> new XmlCodec().decode(in, Object.class));
     }
 
     @Test
     void testSafe2() {
-        try {
-            InputStream in = new ByteArrayInputStream(("<java>\n" + "  <object class=\"java.lang.Runtime\">\n"
-                            + "    <void method=\"exec\">\n"
-                            + "      <string>" + "sleep" + "</string>\n"
-                            + "      <string>" + "60" + "</string>\n"
-                            + "    </void>\n"
-                            + "  </object>\n"
-                            + "</java>")
-                    .getBytes());
-            new XmlCodec().decode(in, Object.class);
-        } catch (Exception e) {
-        }
+        InputStream in = new ByteArrayInputStream(("<java>\n" + "  <object class=\"java.lang.Runtime\">\n"
+                        + "    <void method=\"exec\">\n"
+                        + "      <string>" + "sleep" + "</string>\n"
+                        + "      <string>" + "60" + "</string>\n"
+                        + "    </void>\n"
+                        + "  </object>\n"
+                        + "</java>")
+                .getBytes());
+        assertThrows(DecodeException.class, () -> new XmlCodec().decode(in, Object.class));
     }
 
     static class ProcessChecker {


### PR DESCRIPTION
## Summary
- avoid deserializing unannotated or generic types in `XmlCodec`
- disable external DTD/Schema access when parsing XML
- assert `DecodeException` in `XmlSafetyTest`

## Testing
- `mvn -q -Dtest=org.apache.dubbo.remoting.http12.message.codec.XmlSafetyTest test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3527057348330b2ab8d56029d05fc