### PR TITLE
修复 LRU 缓存缩容时未及时裁剪的问题

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRU2Cache.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRU2Cache.java
@@ -142,8 +142,25 @@ public class LRU2Cache<K, V> extends LinkedHashMap<K, V> {
     }
 
     public void setMaxCapacity(int maxCapacity) {
-        preCache.setMaxCapacity(maxCapacity);
-        this.maxCapacity = maxCapacity;
+        lock.lock();
+        try {
+            preCache.setMaxCapacity(maxCapacity);
+            this.maxCapacity = maxCapacity;
+            trimToSize();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void trimToSize() {
+        while (super.size() > maxCapacity) {
+            java.util.Iterator<java.util.Map.Entry<K, V>> iterator = super.entrySet().iterator();
+            if (!iterator.hasNext()) {
+                return;
+            }
+            iterator.next();
+            iterator.remove();
+        }
     }
 
     static class PreCache<K, V> extends LinkedHashMap<K, V> {
@@ -166,6 +183,18 @@ public class LRU2Cache<K, V> extends LinkedHashMap<K, V> {
 
         public void setMaxCapacity(int maxCapacity) {
             this.maxCapacity = maxCapacity;
+            trimToSize();
+        }
+
+        private void trimToSize() {
+            while (super.size() > maxCapacity) {
+                java.util.Iterator<java.util.Map.Entry<K, V>> iterator = super.entrySet().iterator();
+                if (!iterator.hasNext()) {
+                    return;
+                }
+                iterator.next();
+                iterator.remove();
+            }
         }
     }
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRUCache.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/utils/LRUCache.java
@@ -16,7 +16,9 @@
  */
 package org.apache.dubbo.common.utils;
 
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -148,6 +150,23 @@ public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     }
 
     public void setMaxCapacity(int maxCapacity) {
-        this.maxCapacity = maxCapacity;
+        lock.lock();
+        try {
+            this.maxCapacity = maxCapacity;
+            trimToSize();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void trimToSize() {
+        while (super.size() > maxCapacity) {
+            Iterator<Map.Entry<K, V>> iterator = super.entrySet().iterator();
+            if (!iterator.hasNext()) {
+                return;
+            }
+            iterator.next();
+            iterator.remove();
+        }
     }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRU2CacheTest.java
@@ -67,4 +67,23 @@ class LRU2CacheTest {
         cache.setMaxCapacity(10);
         assertThat(cache.getMaxCapacity(), equalTo(10));
     }
+
+    @Test
+    void testResizeEvictsEldestEntries() {
+        LRU2Cache<String, Integer> cache = new LRU2Cache<String, Integer>(3);
+        cache.put("one", 1);
+        cache.put("one", 1);
+        cache.put("two", 2);
+        cache.put("two", 2);
+        cache.put("three", 3);
+        cache.put("three", 3);
+
+        cache.get("one");
+        cache.setMaxCapacity(2);
+
+        assertThat(cache.size(), equalTo(2));
+        assertTrue(cache.containsKey("one"));
+        assertTrue(cache.containsKey("three"));
+        assertFalse(cache.containsKey("two"));
+    }
 }

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRUCacheTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRUCacheTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.dubbo.common.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LRUCacheTest {
+    @Test
+    void testResizeEvictsEldestEntries() {
+        LRUCache<String, Integer> cache = new LRUCache<>(3);
+        cache.put("one", 1);
+        cache.put("two", 2);
+        cache.put("three", 3);
+
+        cache.get("one");
+        cache.setMaxCapacity(2);
+
+        assertThat(cache.size(), equalTo(2));
+        assertTrue(cache.containsKey("one"));
+        assertTrue(cache.containsKey("three"));
+        assertFalse(cache.containsKey("two"));
+    }
+}


### PR DESCRIPTION
### Motivation
- 在调整缓存 `maxCapacity` 向下时应立即移除超额的最老条目以避免内存膨胀并保证缓存大小一致性（含并发场景）。

### Description
- 在 `LRUCache.setMaxCapacity` 中加入锁保护并调用 `trimToSize()`，以在缩容时立即裁剪多余条目。 
- 在 `LRU2Cache.setMaxCapacity` 与内部 `PreCache.setMaxCapacity` 中同样加入锁与 `trimToSize()`，确保主缓存和历史缓存在调整容量时一致性。 
- 新增 `trimToSize()` 实现，采用迭代 `entrySet()` 并移除最老条目以维护 LRU 顺序，同时添加必要的 `import`。 
- 新增单元测试 `LRUCacheTest` 并扩展 `LRU2CacheTest`，覆盖缩容后应驱逐最老元素的行为。 

### Testing
- 添加的单元测试包含 `dubbo-common/src/test/java/org/apache/dubbo/common/utils/LRUCacheTest.java` 并更新了 `LRU2CacheTest`，测试通过静态断言验证缩容后缓存条目被正确驱逐。 
- 尝试执行 `./mvnw -pl dubbo-common -DskipITs test` 时，Maven Wrapper 在当前环境因网络不可达无法下载依赖导致执行失败，因此无法在该环境完成完整的自动测试运行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ddad0d508330afb0c8f97225465b)